### PR TITLE
Add Observation value-or-dataAbsentReason invariant

### DIFF
--- a/input/fsh/other/RuleSets.fsh
+++ b/input/fsh/other/RuleSets.fsh
@@ -164,3 +164,8 @@ Invariant: no-participation-ops
 Description: "Bundle entries MUST NOT invoke $participate or $hnz-participate."
 Severity: #error
 Expression: "entry.request.url.where($this.matches('[$](participate|hnz-participate)')).exists().not()"
+
+Invariant: value-or-dataabsentreason-required
+Description: "Observations must have a root or component value[x], or a root or component dataAbsentReason."
+Severity: #error
+Expression: "value.exists() or component.value.exists() or dataAbsentReason.exists() or component.dataAbsentReason.exists()"

--- a/input/fsh/profiles/Observation.fsh
+++ b/input/fsh/profiles/Observation.fsh
@@ -12,6 +12,8 @@ Description: "A Shared Digital Health Record Observation."
 
 * insert LocalIdentifierDocs
 
+* obeys value-or-dataabsentreason-required
+
 * extension contains
   hnz-sdhr-client-last-updated-extension named ClientLastUpdated 1..1
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: nz-shared-digital-health-record
 title: NZ Shared Digital Health Record API
 description: NZ Shared Digital Health Record API
 status: active # draft | active | retired | unknown
-version: 1.0.0
+version: 1.0.1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2025+
 releaseLabel: release # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use


### PR DESCRIPTION
## Summary
- add an Observation profile invariant requiring either a root value, component value, root dataAbsentReason, or component dataAbsentReason
- apply the invariant to SDHRObservation in FSH
- rebuild the IG locally to verify the invariant is emitted into generated output

## Validation
- ran `./_genonce.sh`
- publisher completed successfully
- generated output now includes `value-or-dataabsentreason-required` on `SDHRObservation`

## Notes
- the publisher QA report still contains pre-existing errors and warnings unrelated to this change