### PR TITLE
add sdhr-id NamingSystem resource

### DIFF
--- a/input/fsh/terminology/sdhr-naming-system.fsh
+++ b/input/fsh/terminology/sdhr-naming-system.fsh
@@ -1,0 +1,14 @@
+Instance: SDHRIdNamingSystem
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "SDHR Id NamingSystem"
+* description = "The SDHR Id NamingSystem identifies the SDHR resource id namespace published on standards.digital.health.nz. API Consumers should use it when they need a stable system value to reference the FHIR resource ids returned by the SDHR service, for example, when including it in a FHIR Resource outside of SDHR as a secondary identifier."
+* status = #active
+* kind = #identifier
+* date = "2026-06-03"
+* publisher = "Te Whatu Ora / Health New Zealand"
+* responsible = "HISO"
+* usage = "This NamingSystem identifies the SDHR resource id namespace published on standards.digital.health.nz. API Consumers should use it when they need a stable system value to reference the FHIR resource ids returned by the SDHR service, for example, when including it in a FHIR Resource outside of SDHR as a secondary identifier."
+* uniqueId[+].type = #uri
+* uniqueId[=].value = "https://standards.digital.health.nz/ns/sdhr-id"
+* uniqueId[=].preferred = true

--- a/input/pagecontent/api.md
+++ b/input/pagecontent/api.md
@@ -6,6 +6,7 @@ The SDHR API is comprised of multiple FHIR resources. This page provides technic
 | --- | --- |
 | [API Capability Statement](./CapabilityStatement-SDHRCapabilityStatement.html) | FHIR API Capability Statement. Developers should review this to understand the available API interactions and request requirements such as the Request-Context header |
 | [API Artifacts](./artifacts.html) | List of FHIR Artifacts for this API |
+| [SDHR ID NamingSystem](./NamingSystem-SDHRIdNamingSystem.html) | Identifier namespace for SDHR resource ids. API consumers can use this when they want to refer to the FHIR ids returned by SDHR |
 | [OpenAPI Specification](https://fhir-ig.digital.health.nz/openapi/index.html?urls.primaryName=Shared+Digital+Health+Record+FHIR+API) | Machine readable OpenAPI specification for this API |
 | [Participate Operation](./OperationDefinition-SDHRParticipateOperation.html)| Custom operation designed to capture participation information from API Consumers e.g. Patient Management Systems |
 


### PR DESCRIPTION
add a NamingSystem for `sdhr-id`, which documents the namespace `https://standards.digital.health.nz/ns/sdhr-id` for usage as a FHIR Identifier in systems outside of the SDHR Data Service, but where there is value in recording the alternative identifier